### PR TITLE
Opacity Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,18 @@ Similar padding extensions are:
 * `paddingSymmetric` Creates insets with symmetrical vertical and horizontal offsets.
 * `paddingFromWindowPadding` Creates insets that match the given window padding.
 
+### Opacity
+
+```dart
+// Before
+Opacity(
+  opacity: 0.5,
+  child: Text("text"),
+)
+
+// After
+Text("text").setOpacity(0.5)
+```
 
 #### Other
 Now we can just add round corners, shadows, align, and added gestures to our Widgets.

--- a/lib/awesome_extensions.dart
+++ b/lib/awesome_extensions.dart
@@ -2,30 +2,33 @@ library awesome_extensions;
 
 import 'dart:async';
 import 'dart:ui' as ui show WindowPadding;
-export 'package:awesome_extensions/src/platform.dart';
-export 'package:awesome_extensions/src/url_strategy.dart';
-export 'package:awesome_extensions/src/widgets/avatar_image.dart';
+
 import 'package:awesome_extensions/src/platform.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-part 'src/shimmer.dart';
-part 'src/nil.dart';
+export 'package:awesome_extensions/src/platform.dart';
+export 'package:awesome_extensions/src/url_strategy.dart';
+export 'package:awesome_extensions/src/widgets/avatar_image.dart';
+
+part 'context_extensions/dialog_extension.dart';
 part 'context_extensions/media_query_extension.dart';
 part 'context_extensions/navigation_extension.dart';
 part 'context_extensions/theme_extension.dart';
-part 'context_extensions/dialog_extension.dart';
-part 'widget_extensions/shimmer_extension.dart';
+part 'date_extensions/date_extension.dart';
+part 'double_extensions/size_box_extension.dart';
+part 'num_extensions/number_extension.dart';
+part 'src/nil.dart';
+part 'src/shimmer.dart';
+part 'string_extensions/string_extension.dart';
+part 'text_extensions/text_extension.dart';
+part 'text_extensions/text_style_extension.dart';
 part 'widget_extensions/align_extension.dart';
 part 'widget_extensions/center_extension.dart';
 part 'widget_extensions/container_extension.dart';
 part 'widget_extensions/gesture_detector_extension.dart';
-part 'widget_extensions/tooltip_extension.dart';
+part 'widget_extensions/opacity_extension.dart';
 part 'widget_extensions/padding_extension.dart';
-part 'text_extensions/text_extension.dart';
-part 'text_extensions/text_style_extension.dart';
-part 'double_extensions/size_box_extension.dart';
-part 'date_extensions/date_extension.dart';
-part 'num_extensions/number_extension.dart';
-part 'string_extensions/string_extension.dart';
+part 'widget_extensions/shimmer_extension.dart';
+part 'widget_extensions/tooltip_extension.dart';

--- a/lib/context_extensions/theme_extension.dart
+++ b/lib/context_extensions/theme_extension.dart
@@ -22,7 +22,7 @@ extension ThemeExt on BuildContext {
   // COLOR
 
   /// performs a simple [Theme.of(context).backgroundColor] action and returns given [backgroundColor]
-  Color get backgroundColor => Theme.of(this).colorScheme.background;
+  Color get backgroundColor => Theme.of(this).backgroundColor;
 
   /// performs a simple [Theme.of(context).primaryColor] action and returns given [primaryColor]
   Color get primaryColor => Theme.of(this).primaryColor;

--- a/lib/context_extensions/theme_extension.dart
+++ b/lib/context_extensions/theme_extension.dart
@@ -22,7 +22,7 @@ extension ThemeExt on BuildContext {
   // COLOR
 
   /// performs a simple [Theme.of(context).backgroundColor] action and returns given [backgroundColor]
-  Color get backgroundColor => Theme.of(this).backgroundColor;
+  Color get backgroundColor => Theme.of(this).colorScheme.background;
 
   /// performs a simple [Theme.of(context).primaryColor] action and returns given [primaryColor]
   Color get primaryColor => Theme.of(this).primaryColor;

--- a/lib/widget_extensions/opacity_extension.dart
+++ b/lib/widget_extensions/opacity_extension.dart
@@ -1,0 +1,8 @@
+part of '../awesome_extensions.dart';
+
+extension OpacityExtension on Widget {
+  Opacity setOpacity({required double opacity}) => Opacity(
+        opacity: opacity,
+        child: this,
+      );
+}


### PR DESCRIPTION
# Rationale

A dev would set the opacity of a widget by wrapping it with [Opacity](https://api.flutter.dev/flutter/widgets/Opacity-class.html) widget.

```dart
Opacity(
  opacity: 0.5,
  child: Text('foo'),
)
```

With this `OpacityExtension`, now they can simply do this:

```dart
Text('foo').setOpacity(0.5)
```