### PR TITLE
added some media query as inherited widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.9-prerelease] - 2023-06-24
+* By calling `MediaQuery.sizeof(context)`, the widget will rebuild only when the size changes, avoiding unnecessary rebuilds.
+* Add Some media query extension using MediaQuery as Inherited Model
+
 ## [2.0.8] - 2023-05-28
 * Remove `WindowPadding`, This feature was deprecated after v3.8.0-14.0.pre.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ Similar extensions are:
 * `context.isSmallTablet`   // True if the shortestSide is largest than 600p
 * `context.isLargeTablet`    // True if the shortestSide is largest than 720p
 
+MediaQuery as Inherited Model
+Old Way X
+
+MediaQuery.of(context).size;
+MediaQuery.of(context).padding; MediaQuery.of (context). orientation;
+By calling MediaQuery.of(context).size, the widget will rebuild when any of the MediaQuery properties change (less performant).
+
+New Way ✓
+
+MediaQuery.sizeof(context);
+MediaQuery.paddingOf(context); MediaQuery.orientation of (context);
+By calling MediaQuery.sizeof(context), the widget will rebuild only when the size changes, avoiding unnecessary rebuilds.
+
+* `context.mqSize`  // The same of MediaQuery.sizeOf(context)
+* `context.mqHeight`  // The same of MediaQuery.sizeOf(context).height
+* `context.mqWidth`   
+* `context.mqPadding`    // similar to [MediaQuery.paddingOf(context)]
+* `context.mqViewPadding`
+* `context.mqViewInsets`
+* `context.mqOrientation`
+* `context.mqAlwaysUse24HourFormat`
+* `context.mqDevicePixelRatio`
+* `context.mqPlatformBrightness`
+* `context.mqTextScaleFactor`
+
 
 ```dart
 //Check in what platform the app is running

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,9 @@ dependencies:
   - [Widget Extensions](#widget-extensions)
       - [SizeBox](#sizebox)
       - [Padding](#padding)
+      - [Opacity](#opacity)
+      - [Expanded](#expanded)
+      - [Flexible](#flexible)
       - [Other](#other)
       - [Shimmer Effect](#shimmer-effect)
       - [Nil Widget](#nil-widget)
@@ -177,6 +180,31 @@ Similar extensions are:
 * `context.isSmallTablet`   // True if the shortestSide is largest than 600p
 * `context.isLargeTablet`    // True if the shortestSide is largest than 720p
 
+MediaQuery as Inherited Model
+Old Way X
+
+MediaQuery.of(context).size;
+MediaQuery.of(context).padding; MediaQuery.of (context). orientation;
+By calling MediaQuery.of(context).size, the widget will rebuild when any of the MediaQuery properties change (less performant).
+
+New Way ✓
+
+MediaQuery.sizeof(context);
+MediaQuery.paddingOf(context); MediaQuery.orientation of (context);
+By calling MediaQuery.sizeof(context), the widget will rebuild only when the size changes, avoiding unnecessary rebuilds.
+
+* `context.mqSize`  // The same of MediaQuery.sizeOf(context)
+* `context.mqHeight`  // The same of MediaQuery.sizeOf(context).height
+* `context.mqWidth`   
+* `context.mqPadding`    // similar to [MediaQuery.paddingOf(context)]
+* `context.mqViewPadding`
+* `context.mqViewInsets`
+* `context.mqOrientation`
+* `context.mqAlwaysUse24HourFormat`
+* `context.mqDevicePixelRatio`
+* `context.mqPlatformBrightness`
+* `context.mqTextScaleFactor`
+
 
 ```dart
 //Check in what platform the app is running
@@ -291,6 +319,42 @@ Similar padding extensions are:
 * `paddingSymmetric` Creates insets with symmetrical vertical and horizontal offsets.
 * `paddingFromWindowPadding` Creates insets that match the given window padding.
 
+### Opacity
+
+```dart
+// Before
+Opacity(
+  opacity: 0.5,
+  child: Text("text"),
+)
+
+// After
+Text("text").setOpacity(0.5)
+```
+
+### Expanded
+
+```dart
+/// Before
+Expanded(
+  child: Text("text"),
+)
+
+// After
+Text("text").expanded()
+```
+
+### Flexible
+
+```dart
+/// Before
+Flexible(
+  child: Text("text"),
+)
+
+// After
+Text("text").flexible()
+```
 
 #### Other
 Now we can just add round corners, shadows, align, and added gestures to our Widgets.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.8"
+    version: "2.0.9-prerelease"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/context_extensions/media_query_extension.dart
+++ b/lib/context_extensions/media_query_extension.dart
@@ -8,12 +8,12 @@ extension MediaQueryExt on BuildContext {
   /// Note: updates when you rezise your screen (like on a browser or
   /// desktop window)
   /// performs a simple [Theme.of(context).size] action and returns given [height or width]
-  double get height => MediaQuery.of(this).size.height;
+  double get height => mediaQuerySize.height;
 
   /// The same of [MediaQuery.of(context).size.width]
   /// Note: updates when you rezise your screen (like on a browser or
   /// desktop window)
-  double get width => MediaQuery.of(this).size.width;
+  double get width => mediaQuerySize.width;
 
   /// similar to [MediaQuery.of(context).padding]
   EdgeInsets get mediaQueryPadding => MediaQuery.of(this).padding;
@@ -80,4 +80,43 @@ extension MediaQueryExt on BuildContext {
     if (deviceWidth >= 600 && tablet != null) return tablet;
     return mobile;
   }
+
+  /// This change makes MediaQuery an InheritedModel rather than an InheritedWidget,
+  /// so any widget which knows it only depends on a
+  /// specific property of MediaQuery the ability to declare that when reading the MediaQuery from the context.
+
+  /// The same of MediaQuery.sizeOf(context)
+  Size get mqSize => MediaQuery.sizeOf(this);
+
+  /// The same of MediaQuery.sizeOf(context).height
+  double get mqHeight => mqSize.height;
+
+  /// The same of [MediaQuery.sizeOf(context).width]
+  /// Note: updates when you rezise your screen (like on a browser or
+  /// desktop window)
+  double get mqWidth => mqSize.width;
+
+  /// similar to [ MediaQuery.paddingOf(context)]
+  EdgeInsets get mqPadding => MediaQuery.paddingOf(this);
+
+  /// similar to [MediaQuery.viewPaddingOf(context)]
+  EdgeInsets get mqViewPadding => MediaQuery.viewPaddingOf(this);
+
+  /// similar to [MediaQuery.viewInsetsOf(context)]
+  EdgeInsets get mqViewInsets => MediaQuery.viewInsetsOf(this);
+
+  /// similar to [MediaQuery.orientationOf(context)]
+  Orientation get mqOrientation => MediaQuery.orientationOf(this);
+
+  /// similar to [MediaQuery.alwaysUse24HourFormatOf(context)]
+  bool get mqAlwaysUse24HourFormat => MediaQuery.alwaysUse24HourFormatOf(this);
+
+  /// similar to [MediaQuery.devicePixelRatioOf(context)]
+  double get mqDevicePixelRatio => MediaQuery.devicePixelRatioOf(this);
+
+  /// similar to [MediaQuery.platformBrightnessOf(context)]
+  Brightness get mqPlatformBrightness => MediaQuery.platformBrightnessOf(this);
+
+  /// similar to [MediaQuery.textScaleFactorOf(context)]
+  double get mqTextScaleFactor => MediaQuery.textScaleFactorOf(this);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -84,10 +84,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "6b0206b0bf4f04961fc5438198ccb3a885685cd67d4d4a32cc20ad7f8adbe015"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
@@ -182,5 +182,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=3.0.0-417 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=2.10.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: awesome_extensions
 description: An extension to the widget that helps to reduce the boilerplate and adds some helpful methods. and you can make responsive design.
-version: 2.0.8
+version: 2.0.9-prerelease
 homepage: https://jayeshpansheriya.github.io/awesome_extensions
 repository: https://github.com/jayeshpansheriya/awesome_extensions
 issue_tracker: https://github.com/jayeshpansheriya/awesome_extensions/issues


### PR DESCRIPTION
**MediaQuery as Inherited Model**
Old Way X
```
MediaQuery.of(context).size;
MediaQuery.of(context).padding; MediaQuery.of (context). orientation;
```
By calling `MediaQuery.of(context).size`, the widget will rebuild when any of the MediaQuery properties change (less performant).

New Way ✓
```
MediaQuery.sizeof(context);
MediaQuery.paddingOf(context); MediaQuery.orientation of (context);
```
By calling` MediaQuery.sizeof(context)`, the widget will rebuild only when the size changes, avoiding unnecessary rebuilds.