### PR TITLE
Update error handling in async_snapshot_extension

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.12"
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:

--- a/lib/async_extensions/async_snapshot_extension.dart
+++ b/lib/async_extensions/async_snapshot_extension.dart
@@ -54,13 +54,13 @@ extension AsyncSnapshotExt<T> on AsyncSnapshot<T> {
         return loading();
       case ConnectionState.active:
         if (hasError) {
-          return error(error, stackTrace);
+          return error(this.error!, stackTrace);
         } else {
           return data(this.data as T, false);
         }
       case ConnectionState.done:
         if (hasError) {
-          return error(error, stackTrace!);
+          return error(this.error!, stackTrace!);
         } else {
           return data(this.data as T, true);
         }

--- a/test/awesome_extensions_test.dart
+++ b/test/awesome_extensions_test.dart
@@ -1,5 +1,43 @@
+import 'package:awesome_extensions/awesome_extensions.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('adds one to input values', () {});
+
+  group('AsyncSnapshotExt', () {
+    group('when error', () {
+      test('it should return the right error in ConnectionState.active',
+          () async {
+        final err = Exception('Err');
+
+        final snapshot =
+            AsyncSnapshot<int>.withError(ConnectionState.active, err);
+
+        final result = snapshot.when(
+          data: (data, isComplete) => 'Data',
+          error: (error, stackTrace) => error.toString(),
+          loading: () => 'Loading',
+        );
+
+        expect(result, equals(err.toString()));
+      });
+
+      test('it should return the right error in ConnectionState.done',
+          () async {
+        final err = Exception('Err');
+
+        final snapshot =
+            AsyncSnapshot<int>.withError(ConnectionState.done, err);
+
+        final result = snapshot.when(
+          data: (data, isComplete) => 'Data',
+          error: (error, stackTrace) => error.toString(),
+          loading: () => 'Loading',
+        );
+
+        expect(result, equals(err.toString()));
+      });
+    });
+  });
 }


### PR DESCRIPTION
Fixed the way error is returned within async_snapshot_extension for ConnectionState.active and ConnectionState.done. This change has been adequately tested in awesome_extensions_test.dart.

Related issue: https://github.com/jayeshpansheriya/awesome_extensions/issues/27#issue-2174825085