### PR TITLE
refactor: text style fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ Text('Hello World',style: context.displaySmall),
 Text('Hello World',style: context.labelSmall?.bold),
 ```
 
-Similar fontWeight are:
+FontWeight extensions that apply font weights on `TextStyle`:
 
-- `mostThick` The most thick - FontWeight.w900
-- `extraBold` Extra-bold - FontWeight.w800
-- `bold` Bold - FontWeight.bold - FontWeight.w700
-- `semiBold` Semi-bold - FontWeight.w600
-- `medium` Medium - FontWeight.w500
-- `regular` Regular - FontWeight.w400
-- `light` Light - FontWeight.w300
-- `extraLight` Extra-light - FontWeight.w200
-- `thin` Thin, the least thick - FontWeight.w100
+- `mostThick` or `w900` The most thick - FontWeight.w900
+- `extraBold` or `w800` Extra-bold - FontWeight.w800
+- `bold` or `w700` Bold - FontWeight.bold - FontWeight.w700
+- `semiBold` or `w600` Semi-bold - FontWeight.w600
+- `medium` or `w500` Medium - FontWeight.w500
+- `regular` or `w400` Regular - FontWeight.w400
+- `light` or `w300` Light - FontWeight.w300
+- `extraLight` or `w200` Extra-light - FontWeight.w200
+- `thin` or `w100` Thin, the least thick - FontWeight.w100
 
 Similar 2021 TextStyle are:
 

--- a/lib/text_extensions/text_extension.dart
+++ b/lib/text_extensions/text_extension.dart
@@ -14,6 +14,8 @@ extension StyledText<T extends Text> on T {
     int? maxLines,
     String? semanticsLabel,
     TextWidthBasis? textWidthBasis,
+    TextHeightBehavior? textHeightBehavior,
+    Color? selectionColor,
   }) =>
       Text(
         data ?? this.data ?? "",
@@ -28,6 +30,8 @@ extension StyledText<T extends Text> on T {
         textDirection: textDirection ?? this.textDirection,
         textScaler: textScaler ?? this.textScaler,
         textWidthBasis: textWidthBasis ?? this.textWidthBasis,
+        textHeightBehavior: textHeightBehavior ?? this.textHeightBehavior,
+        selectionColor: selectionColor ?? this.selectionColor,
       );
 
   T textStyle(TextStyle? style) => copyWith(
@@ -43,17 +47,20 @@ extension StyledText<T extends Text> on T {
           fontFamily: style?.fontFamily,
           fontFamilyFallback: style?.fontFamilyFallback,
           fontFeatures: style?.fontFeatures,
+          fontVariations: style?.fontVariations,
           fontSize: style?.fontSize,
           fontStyle: style?.fontStyle,
           fontWeight: style?.fontWeight,
           foreground: style?.foreground,
           height: style?.height,
+          leadingDistribution: style?.leadingDistribution,
           inherit: style?.inherit,
           letterSpacing: style?.letterSpacing,
           locale: style?.locale,
           shadows: style?.shadows,
           textBaseline: style?.textBaseline,
           wordSpacing: style?.wordSpacing,
+          overflow: style?.overflow,
         ),
       ) as T;
 

--- a/lib/text_extensions/text_style_extension.dart
+++ b/lib/text_extensions/text_style_extension.dart
@@ -2,38 +2,38 @@ part of '../awesome_extensions.dart';
 
 extension TxtStyle on TextStyle {
   /// The most thick - FontWeight.w900
-  TextStyle get mostThick => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w900);
+  TextStyle get mostThick => copyWith(fontWeight: FontWeight.w900);
+  TextStyle get w900 => copyWith(fontWeight: FontWeight.w900);
 
   /// Extra-bold - FontWeight.w800
-  TextStyle get extraBold => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w800);
+  TextStyle get extraBold => copyWith(fontWeight: FontWeight.w800);
+  TextStyle get w800 => copyWith(fontWeight: FontWeight.w800);
 
   /// Bold - FontWeight.bold - FontWeight.w700
-  TextStyle get bold => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w700);
+  TextStyle get bold => copyWith(fontWeight: FontWeight.w700);
+  TextStyle get w700 => copyWith(fontWeight: FontWeight.w700);
 
   /// Semi-bold - FontWeight.w600
-  TextStyle get semiBold => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w600);
+  TextStyle get semiBold => copyWith(fontWeight: FontWeight.w600);
+  TextStyle get w600 => copyWith(fontWeight: FontWeight.w600);
 
   /// Medium - FontWeight.w500
-  TextStyle get medium => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w500);
+  TextStyle get medium => copyWith(fontWeight: FontWeight.w500);
+  TextStyle get w500 => copyWith(fontWeight: FontWeight.w500);
 
   /// Regular - FontWeight.w400
-  TextStyle get regular => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w400);
+  TextStyle get regular => copyWith(fontWeight: FontWeight.w400);
+  TextStyle get w400 => copyWith(fontWeight: FontWeight.w400);
 
   /// Light - FontWeight.w300
-  TextStyle get light => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w300);
+  TextStyle get light => copyWith(fontWeight: FontWeight.w300);
+  TextStyle get w300 => copyWith(fontWeight: FontWeight.w300);
 
   /// Extra-light - FontWeight.w200
-  TextStyle get extraLight => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w200);
+  TextStyle get extraLight => copyWith(fontWeight: FontWeight.w200);
+  TextStyle get w200 => copyWith(fontWeight: FontWeight.w200);
 
   /// Thin, the least thick - FontWeight.w100
-  TextStyle get thin => TextStyle(
-      fontSize: fontSize, fontFamily: fontFamily, fontWeight: FontWeight.w100);
+  TextStyle get thin => copyWith(fontWeight: FontWeight.w100);
+  TextStyle get w100 => copyWith(fontWeight: FontWeight.w100);
 }


### PR DESCRIPTION
refactor font weight extension methods, should use copyWith
also add additional params for StyledText.copyWith
