### PR TITLE
Add 'separatedby' method to ListExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ dependencies:
     - [Nil Widget](#nil-widget)
     - [SliverToBoxAdapter](#slivertoboxadapter)
     - [Other](#other)
+  - [List Extensions](#list-extensions)
   - [Date Extensions](#date-extensions)
   - [Number Extensions](#number-extensions)
     - [Future \& Duration](#future--duration)
@@ -446,6 +447,28 @@ Automatic detect platform and show material and cupertino dialog
 context.showAlertDialog(title: 'title',
                         message: 'message',)
 ```
+
+## List Extensions
+
+#### SeparatedBy
+
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.center,
+  children: [
+    const Text('Hello').paddingAll(5),
+    const Text('World').paddingAll(5),
+    const Text('Seperated').paddingAll(5),
+    const Text('By').paddingAll(5),
+    const Text('Commas').paddingAll(5),
+  ].separatedby(
+    const Text(','),
+  ),
+),
+```
+
+
+<img  alt="Screenshot 2024-10-10 at 13 34 14" src="https://github.com/user-attachments/assets/b64a6a65-468b-43be-88b5-9ee2271971b9">
 
 ## Date Extensions
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,26 @@ context.showAlertDialog(title: 'title',
 
 ## List Extensions
 
+#### notNullWidget
+  
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.center,
+  children: <Widget?>[
+    Container(
+      height: 100,
+      width: 100,
+      color: Colors.red,
+    ).showIf(true),
+    Container(
+      height: 100,
+      width: 100,
+      color: Colors.green,
+    ).showIf(false),
+  ].notNullWidget(), // returns only not null widgets
+),
+```
+
 #### SeparatedBy
 
 ```dart

--- a/example/lib/widget_ext.dart
+++ b/example/lib/widget_ext.dart
@@ -47,7 +47,20 @@ class WidgetExt extends StatelessWidget {
               ).showIf(false), // or any condition
             ].notNullWidget(), // returns only not null widgets
           ),
-        ],
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Hello').paddingAll(5),
+              const Text('World').paddingAll(5),
+              const Text('Seperated').paddingAll(5),
+              const Text('By').paddingAll(5),
+              const Text('Commas').paddingAll(5),
+            ].separatedby(
+              const Text(','),
+            ),
+          ),
+        ].separatedby(10.heightBox)
       ),
     );
   }

--- a/lib/list_extensions/list_extensions.dart
+++ b/lib/list_extensions/list_extensions.dart
@@ -5,4 +5,33 @@ extension ListExtension on List {
   List<Widget> notNullWidget() {
     return whereType<Widget>().toList();
   }
+
+
+  /// Returns a new list of widgets with the specified separator widget inserted
+  /// between each pair of widgets from the original list.
+  ///
+  /// The method asserts that the list is of type `List<Widget>`.
+  ///
+  /// Example:
+  /// ```dart
+  /// List<Widget> widgets = [Widget1(), Widget2(), Widget3()];
+  /// Widget separator = Divider();
+  /// List<Widget> separatedWidgets = widgets.separatedby(separator);
+  /// // Result: [Widget1(), Divider(), Widget2(), Divider(), Widget3()]
+  /// ```
+  ///
+  /// - Parameter separator: The widget to insert between each pair of widgets.
+  /// - Returns: A new list of widgets with the separator inserted.
+  List<Widget> separatedby(Widget seperator) {
+    assert(this is List<Widget>,
+        'List should be a List<Widget> but is $runtimeType');
+    final List<Widget> list = <Widget>[];
+    for (int i = 0; i < length; i++) {
+      list.add(this[i]);
+      if (i != length - 1) {
+        list.add(seperator);
+      }
+    }
+    return list;
+  }
 }

--- a/test/awesome_extensions_test.dart
+++ b/test/awesome_extensions_test.dart
@@ -290,4 +290,48 @@ void main() {
       });
     });
   });
+
+    group('separatedby', () {
+    test('seperate should insert separator between elements', () {
+      final List<Widget> widgets = [
+        const Text('Item 1'),
+        const Text('Item 2'),
+        const Text('Item 3'),
+      ];
+      const Widget separator = Divider();
+
+      final List<Widget> result = widgets.separatedby(separator);
+
+      expect(result.length, 5);
+      expect(result[0], isInstanceOf<Text>());
+      expect(result[1], isInstanceOf<Divider>());
+      expect(result[2], isInstanceOf<Text>());
+      expect(result[3], isInstanceOf<Divider>());
+      expect(result[4], isInstanceOf<Text>());
+    });
+
+    test('seperate should return empty list when original list is empty', () {
+      final List<Widget> widgets = [];
+      const Widget separator = Divider();
+
+      final List<Widget> result = widgets.separatedby(separator);
+
+      expect(result, isEmpty);
+    });
+
+    test('seperate should return the same list when it contains only one element', () {
+      final List<Widget> widgets = [const Text('Item 1')];
+      const Widget separator = Divider();
+
+      final List<Widget> result = widgets.separatedby(separator);
+
+      expect(result.length, 1);
+      expect(result[0], isInstanceOf<Text>());
+    });
+
+    test('seperate should assert when list is not a List<Widget>', () {
+      final List<int> widgets = [1, 2, 3];
+      expect(() => widgets.separatedby(const Divider()), throwsAssertionError);
+    });
+  });
 }


### PR DESCRIPTION
Resolves #40

This pull request introduces a new method, `separatedby`, to the `ListExtension` class. 

The `separatedby` method allows for the insertion of a specified separator widget between each pair of widgets in a list. Additionally, tests have been added to verify the functionality of the `separatedby` extension method. These tests cover scenarios such as inserting separators between widgets, handling empty lists and single-element lists, and asserting the correct behavior when applied to non-Widget lists.