### PR TITLE
fix: change that force version only to use higher version instead of any version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/jayeshpansheriya/awesome_extensions
 issue_tracker: https://github.com/jayeshpansheriya/awesome_extensions/issues
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
-  flutter: ">=2.10.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.32.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Hi @jayeshpansheriya , I found that your SDK environment constraints are:
```yaml
environment:
  sdk: ">=2.12.0 <4.0.0"
  flutter: ">=2.10.0"
```

Currently, I see that you have not properly constrained the environment of Dart and Flutter. Even though the package supports 3.32.4, apps running lower versions can still run. This leads to the fact that the new features from 3.32.4 you support are not available in lower versions. This leads to the app not being able to build. This MR will limit the constraint to the Flutter version, using 3.32.0 or higher.